### PR TITLE
Deployment generation cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "kudoz-controller",
     "kudoz-crd",

--- a/kudoz-controller/src/utils.rs
+++ b/kudoz-controller/src/utils.rs
@@ -2,6 +2,7 @@ use k8s_openapi::api::apps::v1::Deployment;
 
 pub trait DeploymentExt {
     fn finished_deploying(&self) -> bool;
+    fn namespaced_name(&self) -> String;
 }
 
 impl DeploymentExt for Deployment {
@@ -19,5 +20,15 @@ impl DeploymentExt for Deployment {
         }
 
         return false;
+    }
+
+    fn namespaced_name(&self) -> String {
+        if let (Some(name), Some(namespace)) = (
+            self.metadata.name.as_ref(),
+            self.metadata.namespace.as_ref(),
+        ) {
+            return format!("{namespace}/{name}");
+        }
+        return "<unknown>".into();
     }
 }

--- a/kudoz-crd/src/lib.rs
+++ b/kudoz-crd/src/lib.rs
@@ -2,7 +2,7 @@ use k8s_openapi::api::apps::v1::Deployment;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::collections::BTreeMap;
 
 #[derive(CustomResource, Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 pub struct SuperKudoSpec {
     pub selector: Selector,
     pub deliver_to: DeliverTo,
-    pub payload: Option<JsonValue>,
+    pub payload: Option<JsonMap<String, JsonValue>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, JsonSchema)]
@@ -59,7 +59,7 @@ impl SuperKudo {
         use serde_json::json;
 
         if let Some(ref p) = self.spec.payload {
-            return p.clone();
+            return JsonValue::Object(p.clone());
         } else {
             let text = format!(
                 "Congrats! You just finished deploying {}!",

--- a/superkudos.kudoz.desh.es.yaml
+++ b/superkudos.kudoz.desh.es.yaml
@@ -29,7 +29,9 @@ spec:
                     - slack
                   type: object
                 payload:
+                  additionalProperties: true
                   nullable: true
+                  type: object
                 selector:
                   properties:
                     labels:


### PR DESCRIPTION
Right now this will repeat a webhook many times because when pods restart it can trigger the success case many times. This looks at the generation of the deployment and caches it and only sends a webhook when the generation actually changes. If it's the same, it'll skip sending the webhook.